### PR TITLE
Add text on self-hosting

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -46,6 +46,12 @@ export default {
           { text: 'Contributing', link: '/development/contributing' },
           { text: 'Local Environment', link: '/development/local' },
         ]
+      },
+      {
+        text: 'Self-hosting',
+        items: [
+          { text: 'Self-hosting', link: '/self-hosting/self-hosting' }
+        ]
       }
     ]
   }

--- a/docs/self-hosting/self-hosting.md
+++ b/docs/self-hosting/self-hosting.md
@@ -1,0 +1,15 @@
+---
+title: Self-hosting Omnivore
+editLink: true
+---
+
+# {{ $frontmatter.title }}
+
+[[toc]]
+
+::: danger The self-hosting documentation has not been completed.
+:::
+
+We are working on new documentation and a simplified deployment process for users that wish to self-host.
+
+If you are interested in contributing to the self hosting effort, please join [our Discord](https://discord.gg/h2z5rppzz9).


### PR DESCRIPTION
Mostly doing this so we can deep link to the docs from the iOS
app.
