### PR TITLE
fix: update obsidian default template in the document

### DIFF
--- a/docs/integrations/obsidian.md
+++ b/docs/integrations/obsidian.md
@@ -94,9 +94,11 @@ Default template:
 ```
 ---
 id: {{{id}}}
-title: {{{title}}}
+title: >
+  {{{title}}}
 {{#author}}
-author: {{{author}}}
+author: >
+  {{{author}}}
 {{/author}}
 {{#labels.length}}
 tags:


### PR DESCRIPTION
# Obsidian default template update

I forget to update another place where has the defualt template.

I have updated the default template in the docs/integrations/obsidian.md file. Please check it out.
