### PR TITLE
fixed small typo on Managing Your Account page

### DIFF
--- a/docs/using/managing-account.md
+++ b/docs/using/managing-account.md
@@ -5,7 +5,7 @@ editLink: true
 
 # {{ $frontmatter.title }}
 
-Omnivore offers some extra tools to manager your account and library.
+Omnivore offers some extra tools to manage your account and library.
 
 [[toc]]
 


### PR DESCRIPTION
Changed _"tools to manager your account"_ to _"tools to manage your account"_ on the **Managing your Account and Library** page.