### PR TITLE
Clarify section on CSV importing and fix typos

### DIFF
--- a/docs/using/importing.md
+++ b/docs/using/importing.md
@@ -43,7 +43,7 @@ To start the process, go to the [Integrations](https://omnivore.app/settings/int
 
 ## Importing CSV files
 
-Omnivore can import a list of URLs supplied as a CSV file. The file should be formated as with five columns and a CSV header, the columns are:
+Omnivore can import a list of URLs by supplying a CSV file containing the following columns:
 
 - url: unique URL (full url of the item to be imported).
 - state: Either ARCHIVED or SUCCEEDED (set to ARCHIVED to have your item archived on import). If the state is not specified, the item will be imported as SUCCEEDED.

--- a/docs/using/importing.md
+++ b/docs/using/importing.md
@@ -48,8 +48,8 @@ Omnivore can import a list of URLs by supplying a CSV file containing the follow
 - url: unique URL (full url of the item to be imported).
 - state: Either `ARCHIVED` or `SUCCEEDED`. If set to `ARCHIVED`, the item will be archived upon import. If set to `SUCCEEDED` or left empty, the item is imported and placed in the inbox.
 - labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. Labels may be separated with quotes, which is necessary to include whitespace. Due to CSV quote escaping they will need to be doubled, for example: `"[""label 1"",""label 2""]"`. If the item has no labels this column can be empty.
-- saved_at: The unix timestamp in milliseconds the item was saved. If the item has no saved_at date, this column can be empty.
-- published_at: The unix timestamp in milliseconds the item was published. If the item has no published_at date, this column can be empty.
+- saved_at: The Unix timestamp in milliseconds the item was saved. If the item has no saved_at date, this column can be empty.
+- published_at: The Unix timestamp in milliseconds the item was published. If the item has no published_at date, this column can be empty.
 
 Example File:
 

--- a/docs/using/importing.md
+++ b/docs/using/importing.md
@@ -47,7 +47,7 @@ Omnivore can import a list of URLs supplied as a CSV file. The file should be fo
 
 - url: unique URL (full url of the item to be imported).
 - state: Either ARCHIVED or SUCCEEDED (set to ARCHIVED to have your item archived on import). If the state is not specified, the item will be imported as SUCCEEDED.
-- labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. Labels can also also be separated with quotes, but due to CSV quote escaping they will need to be doubled, for example: `"[""label1"",""label2""]"`. If the item has no labels this column can be empty.
+- labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. Labels may be separated with quotes, which is necessary to include whitespace. Due to CSV quote escaping they will need to be doubled, for example: `"[""label 1"",""label 2""]"`. If the item has no labels this column can be empty.
 - saved_at: The unix timestamp in milliseconds the item was saved. If the item has no saved_at date, this column can be empty.
 - published_at: The unix timestamp in milliseconds the item was published. If the item has no published_at date, this column can be empty.
 

--- a/docs/using/importing.md
+++ b/docs/using/importing.md
@@ -47,7 +47,7 @@ Omnivore can import a list of URLs supplied as a CSV file. The file should be fo
 
 - url: unique URL (full url of the item to be imported).
 - state: Either ARCHIVED or SUCCEEDED (set to ARCHIVED to have your item archived on import). If the state is not specified, the item will be imported as SUCCEEDED.
-- labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. If the item has no labels this column can be empty. Labels can also also be separated with quotes, but due to CSV quote escaping they will need to be doubled, for example: `"[""label1"",""label2""]"`. If the item has no labels this column can be empty.
+- labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. Labels can also also be separated with quotes, but due to CSV quote escaping they will need to be doubled, for example: `"[""label1"",""label2""]"`. If the item has no labels this column can be empty.
 - saved_at: The unix timestamp in milliseconds the item was saved. If the item has no saved_at date, this column can be empty.
 - published_at: The unix timestamp in milliseconds the item was published. If the item has no published_at date, this column can be empty.
 

--- a/docs/using/importing.md
+++ b/docs/using/importing.md
@@ -46,7 +46,7 @@ To start the process, go to the [Integrations](https://omnivore.app/settings/int
 Omnivore can import a list of URLs by supplying a CSV file containing the following columns:
 
 - url: unique URL (full url of the item to be imported).
-- state: Either ARCHIVED or SUCCEEDED (set to ARCHIVED to have your item archived on import). If the state is not specified, the item will be imported as SUCCEEDED.
+- state: Either `ARCHIVED` or `SUCCEEDED`. If set to `ARCHIVED`, the item will be archived upon import. If set to `SUCCEEDED` or left empty, the item is imported and placed in the inbox.
 - labels: In the format `[Label1, Label2, Label3]`, note the square brackets (`[`,`]`) around the list of labels. Labels may be separated with quotes, which is necessary to include whitespace. Due to CSV quote escaping they will need to be doubled, for example: `"[""label 1"",""label 2""]"`. If the item has no labels this column can be empty.
 - saved_at: The unix timestamp in milliseconds the item was saved. If the item has no saved_at date, this column can be empty.
 - published_at: The unix timestamp in milliseconds the item was published. If the item has no published_at date, this column can be empty.


### PR DESCRIPTION
Rephrases some of the [Importing CSV files](https://docs.omnivore.app/using/importing.html#importing-csv-files) section for clarity and fixes typos.