### PR TITLE
Corrected documentation for demo_password

### DIFF
--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -36,7 +36,7 @@ Open `http://localhost:3000` and confirm Omnivore is running
 
 ### 3. Login with the test account
 
-During database setup docker-compose creates an account `demo@omnivore.app`, password: `demo`.
+During database setup docker-compose creates an account `demo@omnivore.app`, password: `demo_password`.
 
 Go to `http://localhost:3000/` in your browser and choose `Continue with Email` to login.
 


### PR DESCRIPTION
Line 24 of the `docker-compose` file says the password is `demo_password`