### PR TITLE
add documentation about org mode integration

### DIFF
--- a/docs/.vitepress/locales/en.ts
+++ b/docs/.vitepress/locales/en.ts
@@ -47,6 +47,7 @@ export const themeConfig: DefaultTheme.Config = {
       items: [
         { text: "Logseq", link: "/integrations/logseq" },
         { text: "Obsidian", link: "/integrations/obsidian" },
+        { text: "Org Mode", link: "/integrations/org-mode" },
         { text: "API", link: "/integrations/api" },
         { text: "Webhooks", link: "/integrations/webhooks" },
       ],

--- a/docs/integrations/org-mode.md
+++ b/docs/integrations/org-mode.md
@@ -1,0 +1,8 @@
+---
+title: Sync all your highlights to an Org Mode file
+editLink: true
+---
+
+# {{ $frontmatter.title }}
+
+There is currently a rudimentary integration with Org Mode via [omnivorg](https://sr.ht/~rehandaphedar/omnivorg). All documentation for it is available on its sourcehut page.


### PR DESCRIPTION
I have written a rudimentary integration with Org Mode. It is not that advanced, just has some basic stuff that I need.

If the project requires that the documentation should also be included in `docs.omnivore` in addition to the integration's page, do let me know. I skipped it because I was worried it would be difficult to keep in sync as the integration gets updates.